### PR TITLE
kubeconfig-bikeshed: bump to v0.3.0

### DIFF
--- a/Formula/kubeconfig-bikeshed.rb
+++ b/Formula/kubeconfig-bikeshed.rb
@@ -1,8 +1,8 @@
 class KubeconfigBikeshed < Formula
   desc "Opinionated tool to manage your kubeconfigs"
   homepage "https://github.com/embik/kubeconfig-bikeshed"
-  url "https://github.com/embik/kubeconfig-bikeshed/archive/refs/tags/v0.2.0.tar.gz"
-  sha256 "a815acbf4217e0d61c9c69e059cb0e75e3e9ce87c8c5b2060f9c7d6846e452fc"
+  url "https://github.com/embik/kubeconfig-bikeshed/archive/refs/tags/v0.3.0.tar.gz"
+  sha256 "ea8b0fc73d673c6be212db39816e53c8557df95bbeae0364244f1a969212c810"
   license "Apache-2.0"
 
   head "https://github.com/embik/kubeconfig-bikeshed.git", branch: "main"


### PR DESCRIPTION
Update to [v0.3.0 "Moka Pot"](https://github.com/embik/kubeconfig-bikeshed/releases/tag/v0.3.0).